### PR TITLE
refactor: replace direct erlang system_time calls with gulid.erl_system_time_millis

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "26.0.2"
-          gleam-version: "1.11"
+          gleam-version: "1.14"
           rebar3-version: "3"
           # elixir-version: "1.15.4"
       - run: gleam deps download

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ In case one needs to create or outpur ULIDs out of
 - binary representation
 
 ```gleam
-import gleam/erlang
 import gleam/int
 import gleam/io
 import gleam/list
@@ -86,7 +85,7 @@ import gulid.{from_parts, from_tuple, to_parts, from_bitarray, to_bitarray}
 pub fn main() {
   let ulid =
     from_parts(
-      erlang.system_time(erlang.Millisecond),
+      gulid.erl_system_time_millis(),
       int.random(99_999_999_999),
     )
   io.println("My ulid made from spare parts:")
@@ -108,7 +107,7 @@ pub fn main() {
   // Ulid from a binary
   let assert Ok(bin_ulid) =
     <<
-      erlang.system_time(erlang.Millisecond):big-48,
+      gulid.erl_system_time_millis():big-48,
       int.random(9_999_999_999):big-80,
     >>
     |> from_bitarray
@@ -152,4 +151,3 @@ gleam run -m example2   # Run the example two
 ```sh
 gleam test  # Run the tests
 ```
-

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "gulid"
-version = "0.0.7"
+version = "0.0.8"
 
 description = "ULID implementation in Gleam (Erlang target only)"
 licences = ["Apache-2.0"]
@@ -8,7 +8,7 @@ repository = { type = "github", user = "vtomilin", repo = "gulid" }
 [dependencies]
 gleam_stdlib = ">= 0.34.0 and < 2.0.0"
 gleam_crypto = ">= 1.3.0 and < 2.0.0"
-gleam_erlang = ">= 0.26.0 and < 1.0.0"
+gleam_erlang = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,14 +2,14 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_crypto", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "917BC8B87DBD584830E3B389CBCAB140FFE7CB27866D27C6D0FB87A9ECF35602" },
-  { name = "gleam_erlang", version = "0.34.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "0C38F2A128BAA0CEF17C3000BD2097EB80634E239CE31A86400C4416A5D0FDCC" },
-  { name = "gleam_stdlib", version = "0.60.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "621D600BB134BC239CB2537630899817B1A42E60A1D46C5E9F3FAE39F88C800B" },
-  { name = "gleeunit", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "12A8A2B510D7063547CD73AE5345544AE92124247A82F46B05F5B0913EE28BC8" },
+  { name = "gleam_crypto", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "50774BAFFF1144E7872814C566C5D653D83A3EBF23ACC3156B757A1B6819086E" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_stdlib", version = "0.67.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "6CE3E4189A8B8EC2F73AB61A2FBDE49F159D6C9C61C49E3B3082E439F260D3D0" },
+  { name = "gleeunit", version = "1.9.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "DA9553CE58B67924B3C631F96FE3370C49EB6D6DC6B384EC4862CC4AAA718F3C" },
 ]
 
 [requirements]
 gleam_crypto = { version = ">= 1.3.0 and < 2.0.0" }
-gleam_erlang = { version = ">= 0.26.0 and < 1.0.0" }
+gleam_erlang = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }

--- a/src/gulid.gleam
+++ b/src/gulid.gleam
@@ -21,7 +21,6 @@
 import gleam/bit_array
 import gleam/crypto
 import gleam/dict
-import gleam/erlang
 import gleam/int
 import gleam/list
 import gleam/order
@@ -71,7 +70,7 @@ pub fn to_string_function() -> fn(Ulid) -> String {
 
 /// Returns a new `Ulid` created from current system time and strong random.
 pub fn new() -> Ulid {
-  let time = erlang.system_time(erlang.Millisecond)
+  let time = erl_system_time_millis()
   let randomness = crypto.strong_random_bytes(10)
   Ulid(<<time:big-48, randomness:bits>>)
 }
@@ -82,7 +81,7 @@ pub fn new() -> Ulid {
 /// random value by 1 (with carry) to produce a new `Ulid` (with the same 
 /// timestamp).
 pub fn new_monotonic(prev_ulid: Ulid) -> Ulid {
-  let time = erlang.system_time(erlang.Millisecond)
+  let time = erl_system_time_millis()
   let assert Ulid(<<prev_time:unsigned-48, random:unsigned-80>>) = prev_ulid
   case int.compare(time, prev_time) {
     order.Eq | order.Lt -> Ulid(<<prev_time:big-48, { random + 1 }:big-80>>)
@@ -286,3 +285,22 @@ fn encode_to_string_with_accumulator(
 fn to_bitarray_130bits(ulid: Ulid) -> BitArray {
   <<0:2, to_bitarray(ulid):bits>>
 }
+
+// Private type to match Erlang's `time_unit()` atom
+type TimeUnit {
+  // Second
+  Millisecond
+  // Microsecond
+  // Nanosecond
+}
+
+/// Returns system time in milliseconds
+/// Like Erlang's `erlang:system_time(millisecond)`
+pub fn erl_system_time_millis() -> Int {
+  // erl_system_time(dynamic.int(1000))
+  erl_system_time(Millisecond)
+}
+
+// fn erl_system_time(unit: dynamic.Dynamic) -> Int
+@external(erlang, "erlang", "system_time")
+fn erl_system_time(unit: TimeUnit) -> Int

--- a/test/gulid_test.gleam
+++ b/test/gulid_test.gleam
@@ -1,4 +1,3 @@
-import gleam/erlang
 import gleam/int
 import gleam/list
 import gleam/order
@@ -69,7 +68,7 @@ pub fn from_string_too_short_test() {
 }
 
 pub fn from_parts_test() {
-  let date_time = erlang.system_time(erlang.Millisecond)
+  let date_time = gulid.erl_system_time_millis()
   let random = int.random(162_554_647_477_263)
   let ulid = from_parts(date_time, random)
   let #(ts, rnd) = to_parts(ulid)


### PR DESCRIPTION
- Remove direct usage of gleam/erlang system_time in favor of new
  erl_system_time_millis helper
- Add erl_system_time_millis and supporting types to gulid module
- Update dependencies to latest compatible versions in gleam.toml and manifest.toml
- Update README and tests to use gulid.erl_system_time_millis for consistency