### PR TITLE
Upgraded to Gleam 1.16, fixed failing monotonic test

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "gulid"
-version = "0.0.8"
+version = "0.0.9"
 
 description = "ULID implementation in Gleam (Erlang target only)"
 licences = ["Apache-2.0"]

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,10 +2,10 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_crypto", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "50774BAFFF1144E7872814C566C5D653D83A3EBF23ACC3156B757A1B6819086E" },
+  { name = "gleam_crypto", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "2DE9E4EF53CF6FEE049D4F765731F7178F7A11AEFAE00EEE63BF7536B354AD3F" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
-  { name = "gleam_stdlib", version = "0.67.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "6CE3E4189A8B8EC2F73AB61A2FBDE49F159D6C9C61C49E3B3082E439F260D3D0" },
-  { name = "gleeunit", version = "1.9.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "DA9553CE58B67924B3C631F96FE3370C49EB6D6DC6B384EC4862CC4AAA718F3C" },
+  { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
+  { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
 ]
 
 [requirements]

--- a/test/gulid_test.gleam
+++ b/test/gulid_test.gleam
@@ -25,8 +25,11 @@ pub fn to_string_success_test() -> #(Ulid, String) {
 }
 
 pub fn monotonic_test() {
-  list.range(0, 9)
-  |> list.scan(new(), fn(ulid, _) { new_monotonic(ulid) })
+  int.range(from: 1, to: 9, with: [new()], run: fn(acc, _) {
+    let assert Ok(last) = list.last(acc)
+    let init = list.take(acc, 1)
+    list.append(init, [new_monotonic(last)])
+  })
   |> list.map(to_string_function())
   |> list.window_by_2
   |> list.all(fn(ulid_pair) {


### PR DESCRIPTION
Upgraded to Gleam 1.16, fixed failing monotonic test due to an upstream breaking change: list.range -> int.range